### PR TITLE
info.rkt: openssl is not a Racket package

### DIFF
--- a/src/info.rkt
+++ b/src/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection "gophwr")
-(define deps '("base" "gui-lib" "openssl"))
+(define deps '("base" "gui-lib"))
 (define build-deps '())
 (define pkg-desc "A graphical gopher browser in Racket")
 (define version "0.3")


### PR DESCRIPTION
Package does not install because of nonexistant dependency.